### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that exposes the official Notion SDK, allowing AI models to interact with Notion workspaces.
 
+<a href="https://glama.ai/mcp/servers/bjc5iac7gt">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/bjc5iac7gt/badge" alt="Notion Server MCP server" />
+</a>
+
 ## Quick Start
 
 ### 1. Set up your Notion integration


### PR DESCRIPTION
This PR adds a badge for the [Notion MCP Server](https://glama.ai/mcp/servers/bjc5iac7gt) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/bjc5iac7gt">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/bjc5iac7gt/badge" alt="Notion Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.